### PR TITLE
Update mobile chat layout

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -22,7 +22,7 @@
   flex-direction: column;
 }
 
-.ai-name{
+.selected-ai{
   border: solid;
   border-width: 1px;
   border-color: black;
@@ -30,11 +30,38 @@
   padding: 1vh;
   cursor: pointer;
   margin-left: 8vh;
-  font-family: monospace; 
+  font-family: monospace;
   font-weight: bold;
   font-size: 2vh;
   color: rgb(66, 66, 66);
 }
+
+.hamburger-icon {
+  display: none;
+  width: 5vh;
+  height: 4vh;
+  margin-top: 1vh;
+  margin-left: 8vh;
+  cursor: pointer;
+  background-color: #fafafa;
+  border: 1px solid black;
+  border-radius: 5px;
+  position: relative;
+}
+
+.hamburger-icon::before,
+.hamburger-icon::after,
+.hamburger-icon div {
+  content: "";
+  position: absolute;
+  left: 10%;
+  right: 10%;
+  height: 2px;
+  background: black;
+}
+.hamburger-icon::before { top: 25%; }
+.hamburger-icon div { top: 50%; }
+.hamburger-icon::after { top: 75%; }
 
 .new-chat-icon{
   display: flex;
@@ -258,10 +285,24 @@
     height: 100vh;
   }
   .side-bar {
-    order: 1;
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
     width: 100%;
-    border-left: none;
-    border-top: 1px solid #dcdcdc;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease-in-out;
+    z-index: 10;
+    overflow-y: auto;
+  }
+  .side-bar.open {
+    transform: translateX(0);
+  }
+  .hamburger-icon {
+    display: block;
+  }
+  .selected-ai {
+    margin-left: 2vh;
   }
   .body {
     order: 2;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ function App() {
   const [FrontendData, setFrontendData]   = useState("");
   const [historyIndex, setHistoryIndex]   = useState(0);
   const [AiName, setAiName]               = useState("");
+  const [isSidebarOpen, setSidebarOpen]   = useState(false);
   const navigate                          = useNavigate();
 
   // load all history indexes
@@ -115,20 +116,30 @@ function App() {
     setClientSideCache([]);
   };
 
+  const handleHamburgerClick = () => {
+    setSidebarOpen(true);
+  };
+
+  const closeSidebar = () => {
+    setSidebarOpen(false);
+  };
+
   const handleGetPreviousChat = (idx) => {
     setHistoryIndex(idx);
     getUserAiChat(idx);
+    setSidebarOpen(false);
   };
 
   return (
     <div className="app">
       <div className="header">
-        <p className="ai-name" onClick={() => navigate("/")}>
-          Selected AI: {AiName} (click to repick ai)
-        </p>
+        <p className="selected-ai" onClick={() => navigate("/")}>Selected AI: {AiName}</p>
+        <div className="hamburger-icon" onClick={handleHamburgerClick}>
+          <div></div>
+        </div>
       </div>
 
-      <div className="side-bar">
+      <div className={`side-bar ${isSidebarOpen ? "open" : ""}`}>
         <div className="side-bar-buttons">
           <div className="new-chat-icon" onClick={handleNewChat}>Make New Chat</div>
           <div className="new-chat-icon" onClick={() => handleDeleteChat(historyIndex)}>Delete Current Chat</div>


### PR DESCRIPTION
## Summary
- hide sidebar on mobile by default and add slide-in menu
- add hamburger icon and selected AI header text on mobile
- close sidebar when selecting a chat

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b3fa335c8332ad6b7af273b89f58